### PR TITLE
Added Podspec For CocoaPods

### DIFF
--- a/MAFormViewController.podspec
+++ b/MAFormViewController.podspec
@@ -3,7 +3,9 @@ Pod::Spec.new do |spec|
   spec.version          = '1.0'
   spec.homepage         = 'https://github.com/mamaral/MAFormViewController'
   spec.authors          = 'Mike Amaral'
+  spec.platform         = :ios
   spec.summary          = 'MAFormViewController is designed to be used in tandem with MATextFieldCells for extremely quick and easy UITableView-based form creation that automatically handles the form configuration, formatting, navigation, validation, and submission.'
-  spec.source           =  { :git => 'https://github.com/Whelton/MAFormViewController.git', :tag => 'v1.0' }
+  spec.source           =  { :git => 'https://github.com/Whelton/MAFormViewController.git' }
   spec.source_files     = 'MAFormViewController/MAFormViewController.{h,m}', 'MAFormViewController/MAFormField.{h,m}', 'MAFormViewController/MATextFieldCell.{h,m}'
+  spec.requires_arc 	  = true
 end


### PR DESCRIPTION
Added a .podspec file so people can integrate MAFormViewController into their project via CocoaPods.

At time of writing they can do it by adding the following to their Podfile, which uses the podspec file on my fork
`pod 'MAFormViewController', :git => 'https://github.com/Whelton/MAFormViewController.git'`

If merged, then it can go forward to the main CocoaPods repo so anyone can add it with simply:
`pod 'MAFormViewController'`
at that point I would suggest creating a tag on the main repo for version control with CocoaPods. 
